### PR TITLE
getAllColumnsAsListメソッドを消しました

### DIFF
--- a/src/Constants/TableConstants/CATEGORY_MASTER.java
+++ b/src/Constants/TableConstants/CATEGORY_MASTER.java
@@ -32,10 +32,6 @@ public enum CATEGORY_MASTER {
         return TABLES.getAllColumnsWithComma(CATEGORY_MASTER.class);
     }
     
-    public static List<String> getAllColumnsAsStringList(){
-        return TABLES.getAllColumnsAsStringList(CATEGORY_MASTER.class);
-    }
-
     public String getColumn() {
         return this.name();
     }

--- a/src/Constants/TableConstants/PRODUCT_MASTER.java
+++ b/src/Constants/TableConstants/PRODUCT_MASTER.java
@@ -38,10 +38,6 @@ public enum PRODUCT_MASTER implements TABLES {
         return TABLES.getAllColumnsWithComma(PRODUCT_MASTER.class);
     }
     
-    public static List<String> getAllColumnsAsStringList(){
-        return TABLES.getAllColumnsAsStringList(PRODUCT_MASTER.class);
-    }
-
     public String getColumn() {
         return this.name();
     }

--- a/src/Constants/TableConstants/TABLES.java
+++ b/src/Constants/TableConstants/TABLES.java
@@ -51,20 +51,6 @@ public interface TABLES {
         return sb.toString();
     }
 
-    static <T> List<String> getAllColumnsAsStringList(final Class<T> clazz) {
-        List<String> allColumns = new ArrayList<>();
-
-        if (clazz.isEnum()) {
-            for (Field field : clazz.getFields()) {
-                allColumns.add(field.getName());
-            }
-        }else{
-            throwIllegalArgumentException();
-        }
-
-        return allColumns;
-    }
-
     static void throwIllegalArgumentException() {
         try {
             throw new IllegalArgumentException("列挙型のクラスインスタンス以外を渡さないでください");


### PR DESCRIPTION
getAllColumnsAsListメソッドを消しました。

画面でプルダウンを表示する時に、カラム名のリストがいると勘違いして、すべてのカラム名をリストで返すメソッドを作ってしまいました。

プルダウンで表示するのはカラム名ではなく値なので、このメソッドは要りません。なので削除しました。